### PR TITLE
PR: Update Jedi asset for its 0.18 version

### DIFF
--- a/jedi/__main__.py
+++ b/jedi/__main__.py
@@ -1,5 +1,13 @@
 import os
 import sys
+from importlib.abc import MetaPathFinder
+from importlib.machinery import PathFinder
+
+# Remove the first entry, because it's simply a directory entry that equals
+# this directory.
+# NOTE: Commented out line to be able to run jedi with the default interpreter
+# of the Spyder installation
+# del sys.path[0]
 
 
 def _get_paths():
@@ -11,47 +19,24 @@ def _get_paths():
     return {'jedi': _jedi_path, 'parso': _parso_path}
 
 
-# Remove the first entry, because it's simply a directory entry that equals
-# this directory.
-# NOTE: Commented out line to be able to run jedi with the default interpreter
-# of the Spyder installation
-# del sys.path[0]
+class _ExactImporter(MetaPathFinder):
+    def __init__(self, path_dct):
+        self._path_dct = path_dct
 
-if sys.version_info > (3, 4):
-    from importlib.machinery import PathFinder
+    def find_module(self, fullname, path=None):
+        if path is None and fullname in self._path_dct:
+            p = self._path_dct[fullname]
+            loader = PathFinder.find_module(fullname, path=[p])
+            return loader
+        return None
 
-    class _ExactImporter(object):
-        def __init__(self, path_dct):
-            self._path_dct = path_dct
 
-        def find_module(self, fullname, path=None):
-            if path is None and fullname in self._path_dct:
-                p = self._path_dct[fullname]
-                loader = PathFinder.find_module(fullname, path=[p])
-                return loader
-            return None
-
-    # Try to import jedi/parso.
-    sys.meta_path.insert(0, _ExactImporter(_get_paths()))
-    from jedi.inference.compiled import subprocess  # NOQA
-    sys.meta_path.pop(0)
-else:
-    import imp
-
-    def load(name):
-        paths = list(_get_paths().values())
-        fp, pathname, description = imp.find_module(name, paths)
-        return imp.load_module(name, fp, pathname, description)
-
-    load('parso')
-    load('jedi')
-    from jedi.inference.compiled import subprocess  # NOQA
-
-from jedi._compatibility import highest_pickle_protocol  # noqa: E402
-
+# Try to import jedi/parso.
+sys.meta_path.insert(0, _ExactImporter(_get_paths()))
+from jedi.inference.compiled import subprocess  # noqa: E402
+sys.meta_path.pop(0)
 
 # Retrieve the pickle protocol.
 host_sys_version = [int(x) for x in sys.argv[2].split('.')]
-pickle_protocol = highest_pickle_protocol([sys.version_info, host_sys_version])
 # And finally start the client.
-subprocess.Listener(pickle_protocol=pickle_protocol).listen()
+subprocess.Listener().listen()


### PR DESCRIPTION
Since we now support that version (thanks to spyder-ide/spyder#15878), we needed to update the corresponding asset here.

I can confirm this fixes all functionality related to Jedi in Spyder 5.1