### PR TITLE
PR: Add flag to kill child processes if Spyder is open while running installer and fixes uninstall failing validation

### DIFF
--- a/nsist/spyder.nsi
+++ b/nsist/spyder.nsi
@@ -308,6 +308,7 @@ Function validate_pre_install
     ${If} $0 <> 0
   		MessageBox MB_YESNO|MB_ICONSTOP "Failed to uninstall, continue anyway?" /SD IDYES IDYES NotInstalled IDNO NoUninstall
 	  ${EndIf}
+    GoTo NotInstalled
   NoUninstall:
     Quit
   NotInstalled:

--- a/nsist/spyder.nsi
+++ b/nsist/spyder.nsi
@@ -274,8 +274,10 @@ Function validate_pre_install
                                               MessageBox MB_YESNO|MB_ICONINFORMATION "All unsaved files and changes will be lost. All ${PRODUCT_NAME} running processes will stop. Are you sure you are want to close ${PRODUCT_NAME}?" \
                                                                                       /SD IDYES IDYES CloseSpyder IDNO NoClose
                                               CloseSpyder:
+                                                Banner::show /set 76 "Please wait while closing Spyder..." " "
                                                 nsExec::Exec 'TaskKill /FI "WINDOWTITLE eq Spyder" /F /T'
-                                                goto notRunning
+                                                Banner::destroy
+                                                GoTo notRunning
                                             NoClose:
                                               Quit
   notRunning:
@@ -301,13 +303,10 @@ Function validate_pre_install
     ExecWait '"$uninstallPreviousInstallation" /S _?=$INSTDIR'
     Banner::destroy
     ${If} $0 <> 0
-		MessageBox MB_YESNO|MB_ICONSTOP "Failed to uninstall, continue anyway?" /SD IDYES IDYES +2
-			Abort
+  		MessageBox MB_YESNO|MB_ICONSTOP "Failed to uninstall, continue anyway?" /SD IDYES IDYES NotInstalled IDNO NoUninstall
 	  ${EndIf}
-    GoTo NotInstalled
   NoUninstall:
     Quit
-      
   NotInstalled:
 FunctionEnd
 

--- a/nsist/spyder.nsi
+++ b/nsist/spyder.nsi
@@ -274,7 +274,7 @@ Function validate_pre_install
                                               MessageBox MB_YESNO|MB_ICONINFORMATION "All unsaved files and changes will be lost. All ${PRODUCT_NAME} running processes will stop. Are you sure you are want to close ${PRODUCT_NAME}?" \
                                                                                       /SD IDYES IDYES CloseSpyder IDNO NoClose
                                               CloseSpyder:
-                                                nsExec::Exec 'TaskKill /FI "WINDOWTITLE eq Spyder" /F'
+                                                nsExec::Exec 'TaskKill /FI "WINDOWTITLE eq Spyder" /F /T'
                                                 goto notRunning
                                             NoClose:
                                               Quit

--- a/nsist/spyder.nsi
+++ b/nsist/spyder.nsi
@@ -300,7 +300,10 @@ Function validate_pre_install
                                             /SD IDYES IDYES UninstallPreviousInstallation IDNO NoUninstall
   UninstallPreviousInstallation:
     Banner::show /set 76 "Please wait while uninstalling..." " "
-    ExecWait '"$uninstallPreviousInstallation" /S _?=$INSTDIR'
+    CreateDirectory $TEMP\spyder-uninstaller
+    CopyFiles /SILENT "$uninstallPreviousInstallation" $TEMP\spyder-uninstaller\uninstall.exe
+    ExecWait '"$TEMP\spyder-uninstaller\uninstall.exe" /S _?=$INSTDIR' $0
+    RMDir /r $TEMP\spyder-uninstaller
     Banner::destroy
     ${If} $0 <> 0
   		MessageBox MB_YESNO|MB_ICONSTOP "Failed to uninstall, continue anyway?" /SD IDYES IDYES NotInstalled IDNO NoUninstall

--- a/nsist/spyder.nsi
+++ b/nsist/spyder.nsi
@@ -268,13 +268,13 @@ Function validate_pre_install
 
   FindWindow $0 "" "${PRODUCT_NAME}"
   IntCmp $0 0 notRunning
-    MessageBox MB_YESNO|MB_ICONINFORMATION "${PRODUCT_NAME} is running. You will need to close it first to proceed. Do you want to close ${PRODUCT_NAME} now?" \
+    MessageBox MB_YESNO|MB_ICONINFORMATION "${PRODUCT_NAME} is running. It is necessary to close it before installing a new version. Do you want to close ${PRODUCT_NAME} now?" \
                                             /SD IDYES IDYES Confirm IDNO NoClose
                                             Confirm:
-                                              MessageBox MB_YESNO|MB_ICONINFORMATION "All unsaved files and changes will be lost. All ${PRODUCT_NAME} running processes will stop. Are you sure you are want to close ${PRODUCT_NAME}?" \
+                                              MessageBox MB_YESNO|MB_ICONINFORMATION "All unsaved files and changes will be lost. In addition, any program that you are running in ${PRODUCT_NAME}'s IPython console will be stopped. Are you sure you want to close ${PRODUCT_NAME}?" \
                                                                                       /SD IDYES IDYES CloseSpyder IDNO NoClose
                                               CloseSpyder:
-                                                Banner::show /set 76 "Please wait while closing Spyder..." " "
+                                                Banner::show /set 76 "Please wait while closing ${PRODUCT_NAME}..." " "
                                                 nsExec::Exec 'TaskKill /FI "WINDOWTITLE eq Spyder" /F /T'
                                                 Banner::destroy
                                                 GoTo notRunning
@@ -299,15 +299,12 @@ Function validate_pre_install
     MessageBox MB_YESNO|MB_ICONINFORMATION "${PRODUCT_NAME} is already installed. Uninstall the existing version?" \
                                             /SD IDYES IDYES UninstallPreviousInstallation IDNO NoUninstall
   UninstallPreviousInstallation:
-    Banner::show /set 76 "Please wait while uninstalling..." " "
+    Banner::show /set 76 "Please wait while uninstalling ${PRODUCT_NAME}..." " "
     CreateDirectory $TEMP\spyder-uninstaller
     CopyFiles /SILENT "$uninstallPreviousInstallation" $TEMP\spyder-uninstaller\uninstall.exe
-    ExecWait '"$TEMP\spyder-uninstaller\uninstall.exe" /S _?=$INSTDIR' $0
+    ExecWait '"$TEMP\spyder-uninstaller\uninstall.exe" /S _?=$INSTDIR'
     RMDir /r $TEMP\spyder-uninstaller
     Banner::destroy
-    ${If} $0 <> 0
-  		MessageBox MB_YESNO|MB_ICONSTOP "Failed to uninstall, continue anyway?" /SD IDYES IDYES NotInstalled IDNO NoUninstall
-	  ${EndIf}
     GoTo NotInstalled
   NoUninstall:
     Quit


### PR DESCRIPTION
Adds a flag to the `TaskKill` command to prevent leaving processes open before running the uninstaller and some other fixes to the uninstall validation logic

Also, just in case, a preview of the changes that @jsbautista was working on at #10 to also use this PR to have more feedback from @ccordoba12 regarding the messages on the new dialogs and do changes if needed:

### Spyder running detected (new dialog)

![imagen](https://user-images.githubusercontent.com/16781833/177610444-5b240fa2-1eb5-4f01-a886-a17e78929458.png)

### Confirmation to kill Spyder process (new dialog)

![imagen](https://user-images.githubusercontent.com/16781833/177610475-a7cdee1c-7697-460a-adfe-e863c8d22aaf.png)

### Placeholder banner while clsoing Spyder (new dialog)
![imagen](https://user-images.githubusercontent.com/16781833/177632689-ed211ec2-2387-477a-af9b-10d930b9946e.png)


### Spyder installation detected (old dialog)
![imagen](https://user-images.githubusercontent.com/16781833/177610530-99c21536-02ba-474f-b22c-ec0d29b48241.png)

### Placeholder banner while the uninstall is being done (new dialog)
![imagen](https://user-images.githubusercontent.com/16781833/177610564-bf2504be-164f-4d74-ae33-2adaf77931b8.png)

### Uninstall failed (new dialog)
![imagen](https://user-images.githubusercontent.com/16781833/177610615-445d6d29-3190-4718-9272-27df4a660016.png)

### Start Spyder after installation (new dialog)
![imagen](https://user-images.githubusercontent.com/16781833/177612641-cfeec19e-7453-45ea-80b4-ecf777fcf64c.png)

